### PR TITLE
Catch case causing `Permission denied error` error to appear on Firefox

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -23,18 +23,28 @@ export function precacheFiberNode(hostInst, node) {
  * ReactDOMTextComponent instance ancestor.
  */
 export function getClosestInstanceFromNode(node) {
-  if (node[internalInstanceKey]) {
-    return node[internalInstanceKey];
-  }
-
-  while (!node[internalInstanceKey]) {
-    if (node.parentNode) {
-      node = node.parentNode;
-    } else {
-      // Top of the tree. This node must not be part of a React tree (or is
-      // unmounted, potentially).
-      return null;
+  // In Firefox, anchorNode and focusNode can be "anonymous divs", e.g. the
+  // up/down buttons on an <input type="number">. Anonymous divs do not seem to
+  // expose properties, triggering a "Permission denied error" if any of its
+  // properties are accessed. The only seemingly possible way to avoid erroring
+  // is to access a property that typically works for non-anonymous divs and
+  // catch any error that may otherwise arise. See
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+  try {
+    if (node[internalInstanceKey]) {
+      return node[internalInstanceKey];
     }
+    while (!node[internalInstanceKey]) {
+      if (node.parentNode) {
+        node = node.parentNode;
+      } else {
+        // Top of the tree. This node must not be part of a React tree (or is
+        // unmounted, potentially).
+        return null;
+      }
+    }
+  } catch (e) {
+    return null;
   }
 
   let inst = node[internalInstanceKey];


### PR DESCRIPTION
this issue is similar to the issue https://github.com/facebook/react/issues/10181

in Firefox, anchorNode and focusNode can be "anonymous divs", e.g. the up/down buttons on an <input type="number">. Anonymous divs do not seem to expose properties, triggering a "Permission denied error" if any of its properties are accessed. The only seemingly possible way to avoid erroring is to access a property that typically works for non-anonymous divs and catch any error that may otherwise arise. read more https://bugzilla.mozilla.org/show_bug.cgi?id=208427

please review and merge it, thank you!

_update: screenshot error record_ 

![image](https://user-images.githubusercontent.com/9839768/50432252-1d249780-0903-11e9-9b62-7a272dbf5eba.png)
