### PR TITLE
warn when it looks like you haven't updated react-dom

### DIFF
--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -19,6 +19,13 @@ function resolveDispatcher() {
     dispatcher !== null,
     'Hooks can only be called inside the body of a function component.',
   );
+  if (__DEV__) {
+    warning(
+      typeof dispatcher.useState === 'function',
+      "It looks like you're using an older version of your renderer, " +
+        "make sure you've updated both react and react-<renderer> in your package.json",
+    );
+  }
   return dispatcher;
 }
 


### PR DESCRIPTION
sketching a possible "fix" for #14039 for discussion. 

- icky error message, I know. 
- can't think of a good test for this, open to suggestions. should I mock the dispatcher to trigger this specific error? sounds self serving. 
- should probably add a TODO to remove this in v17

